### PR TITLE
Issue #28: `composer.json` cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Documentation is available at: https://docs.dotkernel.org/light-documentation/
 ## Badges
 
 ![OSS Lifecycle](https://img.shields.io/osslifecycle/dotkernel/light)
-![PHP from Packagist (specify version)](https://img.shields.io/packagist/php-v/dotkernel/light/1.1.0)
+![PHP from Packagist (specify version)](https://img.shields.io/packagist/php-v/dotkernel/light/1.1.1)
 
 [![GitHub issues](https://img.shields.io/github/issues/dotkernel/light)](https://github.com/dotkernel/light/issues)
 [![GitHub forks](https://img.shields.io/github/forks/dotkernel/light)](https://github.com/dotkernel/light/network)

--- a/composer.json
+++ b/composer.json
@@ -27,25 +27,24 @@
     },
     "require": {
         "php": "~8.2.0 || ~8.3.0 || ~8.4.0",
-        "dotkernel/dot-controller": "^4.0.0",
-        "dotkernel/dot-errorhandler": "^4.1.0",
-        "friendsofphp/proxy-manager-lts": "^1.0.16",
-        "laminas/laminas-component-installer": "^3.4.0",
-        "laminas/laminas-config-aggregator": "^1.14.0",
-        "mezzio/mezzio": "^3.18.0",
-        "mezzio/mezzio-fastroute": "^3.11.0",
-        "mezzio/mezzio-twigrenderer": "^2.12"
+        "dotkernel/dot-controller": "^4.0.1",
+        "dotkernel/dot-errorhandler": "^4.1.1",
+        "laminas/laminas-component-installer": "^3.5.0",
+        "laminas/laminas-config-aggregator": "^1.17.0",
+        "mezzio/mezzio": "^3.20.1",
+        "mezzio/mezzio-fastroute": "^3.12.0",
+        "mezzio/mezzio-twigrenderer": "^2.17.0"
     },
     "require-dev": {
-        "filp/whoops": "^2.16.0",
-        "laminas/laminas-coding-standard": "^3.0",
-        "laminas/laminas-development-mode": "^3.12.0",
-        "phpstan/phpstan": "^2.0",
-        "phpstan/phpstan-phpunit": "^2.0",
-        "phpunit/phpunit": "^10.5",
+        "filp/whoops": "^2.17.0",
+        "laminas/laminas-coding-standard": "^3.0.1",
+        "laminas/laminas-development-mode": "^3.13.0",
+        "phpstan/phpstan": "^2.1.2",
+        "phpstan/phpstan-phpunit": "^2.0.4",
+        "phpunit/phpunit": "^10.5.45",
         "roave/security-advisories": "dev-master",
-        "symfony/var-dumper": "^7.1",
-        "vincentlanglet/twig-cs-fixer": "^3.5"
+        "symfony/var-dumper": "^7.2.3",
+        "vincentlanglet/twig-cs-fixer": "^3.5.1"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Ran through all Composer dependencies to check the purpose of each package:

- `require`:
  - `dotkernel/dot-controller`: will be removed when #27 is implemented
  - `dotkernel/dot-errorhandler`: used for logging errors
  - `friendsofphp/proxy-manager-lts`: removed in this PR
  - `laminas/laminas-component-installer`: used by Laminas to inject ConfigProviders into `config/config.php`
  - `laminas/laminas-config-aggregator`: combines config files found under `config/`
  - `mezzio/mezzio`: the Mezzio framework
  - `mezzio/mezzio-fastroute`: routing package
  - `mezzio/mezzio-twigrenderer`: template renderer
- `require-dev`
  - `filp/whoops`: Whoops error handler
  - `laminas/laminas-coding-standard`: Laminas coding standard specs
  - `laminas/laminas-development-mode`: toggle development mode
  - `phpstan/phpstan`: static analysis tool
  - `phpstan/phpstan-phpunit`: PHPUnit extensions for PHPStan
  - `phpunit/phpunit`: unit tests
  - `roave/security-advisories`: warns about package vulnerabilities
  - `symfony/var-dumper`: dd($something)
  - `vincentlanglet/twig-cs-fixer`: Twig coding standards checker/fixer