### PR TITLE
Documentation Remove "Configuration - First Run"

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,6 @@ Documentation is available at: https://docs.dotkernel.org/light-documentation/
     - [Composer](#composer)
     - [Choose a destination path for Dotkernel `light` installation](#choosing-an-installation-path-for-dotkernel-light)
     - [Installing Dotkernel light](#installing-dotkernel-light)
-    - [Configuration - First Run](#configuration---first-run)
     - [Testing (Running)](#running-the-application)
 
 ## Tools

--- a/README.md
+++ b/README.md
@@ -90,10 +90,6 @@ The next question is:
 
 You should enter `y` and press `Enter`.
 
-## Configuration - First Run
-
-- duplicate `config/autoload/local.php.dist` as `config/autoload/local.php`
-
 ## Development mode
 
 Run this command to enable dev mode by turning debug flag to `true` and turning configuration caching to `off`. It will also make sure that any existing config cache is cleared.


### PR DESCRIPTION
From the documentation:
"duplicate `config/autoload/local.php.dist` as `config/autoload/local.php`"

`config/autoload/local.php` is already filled with the values from `config/autoload/local.php.dist` when the repository is cloned. Should we remove this ? 