### PR TITLE
Issue #42: Refactored `PageHandler` to reflect naming standard.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
     },
     "require": {
         "php": "~8.2.0 || ~8.3.0 || ~8.4.0",
-        "dotkernel/dot-errorhandler": "^4.2.0",
+        "dotkernel/dot-errorhandler": "^4.2.1",
         "laminas/laminas-component-installer": "^3.5.0",
         "laminas/laminas-config-aggregator": "^1.17.0",
         "mezzio/mezzio": "^3.20.1",

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
     },
     "require": {
         "php": "~8.2.0 || ~8.3.0 || ~8.4.0",
-        "dotkernel/dot-errorhandler": "^4.1.1",
+        "dotkernel/dot-errorhandler": "^4.2.0",
         "laminas/laminas-component-installer": "^3.5.0",
         "laminas/laminas-config-aggregator": "^1.17.0",
         "mezzio/mezzio": "^3.20.1",
@@ -66,7 +66,6 @@
         "development-disable": "laminas-development-mode disable",
         "development-enable": "laminas-development-mode enable",
         "development-status": "laminas-development-mode status",
-        "mezzio": "mezzio --ansi",
         "check": [
             "@cs-check",
             "@twig-cs-check",

--- a/config/autoload/error-handling.global.php
+++ b/config/autoload/error-handling.global.php
@@ -2,30 +2,41 @@
 
 declare(strict_types=1);
 
+use Dot\ErrorHandler\Extra\ExtraProvider;
+use Dot\ErrorHandler\Extra\Processor\TraceProcessor;
+use Dot\ErrorHandler\Extra\Provider\TraceProvider;
 use Dot\Log\Formatter\Json;
 use Dot\Log\Logger;
 
 return [
     'dot-errorhandler' => [
-        'loggerEnabled' => true,
-        'logger'        => 'dot-log.default_logger',
+        'loggerEnabled'           => true,
+        'logger'                  => 'dot-log.default_logger',
+        ExtraProvider::CONFIG_KEY => [
+            TraceProvider::class => [
+                'enabled'   => true,
+                'processor' => [
+                    'class' => TraceProcessor::class,
+                ],
+            ],
+        ],
     ],
     'dot_log'          => [
         'loggers' => [
             'default_logger' => [
                 'writers' => [
                     'FileWriter' => [
-                        'name'     => 'stream',
-                        'priority' => Logger::ALERT,
-                        'options'  => [
+                        'name'    => 'stream',
+                        'level'   => Logger::ALERT,
+                        'options' => [
                             'stream' => __DIR__ . '/../../log/error-log-{Y}-{m}-{d}.log',
                             // explicitly log all messages
                             'filters'   => [
                                 'allMessages' => [
-                                    'name'    => 'priority',
+                                    'name'    => 'level',
                                     'options' => [
                                         'operator' => '>=',
-                                        'priority' => Logger::EMERG,
+                                        'level'    => Logger::EMERG,
                                     ],
                                 ],
                             ],

--- a/src/Page/src/ConfigProvider.php
+++ b/src/Page/src/ConfigProvider.php
@@ -6,8 +6,7 @@ namespace Light\Page;
 
 use Light\Page\Factory\PageHandlerFactory;
 use Light\Page\Factory\PageServiceFactory;
-use Light\Page\Handler\PageHandler;
-use Light\Page\RoutesDelegator;
+use Light\Page\Handler\GetPageViewHandler;
 use Light\Page\Service\PageService;
 use Light\Page\Service\PageServiceInterface;
 use Mezzio\Application;
@@ -31,8 +30,8 @@ class ConfigProvider
                 ],
             ],
             'factories'  => [
-                PageHandler::class => PageHandlerFactory::class,
-                PageService::class => PageServiceFactory::class,
+                GetPageViewHandler::class => PageHandlerFactory::class,
+                PageService::class        => PageServiceFactory::class,
             ],
             'aliases'    => [
                 PageServiceInterface::class => PageService::class,

--- a/src/Page/src/Factory/PageHandlerFactory.php
+++ b/src/Page/src/Factory/PageHandlerFactory.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Light\Page\Factory;
 
-use Light\Page\Handler\PageHandler;
+use Light\Page\Handler\GetPageViewHandler;
 use Mezzio\Template\TemplateRendererInterface;
 use Psr\Container\ContainerExceptionInterface;
 use Psr\Container\ContainerInterface;
@@ -19,11 +19,11 @@ class PageHandlerFactory
      * @throws NotFoundExceptionInterface
      * @throws ContainerExceptionInterface
      */
-    public function __invoke(ContainerInterface $container, string $requestedName): PageHandler
+    public function __invoke(ContainerInterface $container, string $requestedName): GetPageViewHandler
     {
         $template = $container->get(TemplateRendererInterface::class);
         assert($template instanceof TemplateRendererInterface);
 
-        return new PageHandler($template);
+        return new GetPageViewHandler($template);
     }
 }

--- a/src/Page/src/Handler/GetPageViewHandler.php
+++ b/src/Page/src/Handler/GetPageViewHandler.php
@@ -11,7 +11,7 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 
-class PageHandler implements RequestHandlerInterface
+class GetPageViewHandler implements RequestHandlerInterface
 {
     public function __construct(
         protected TemplateRendererInterface $template,

--- a/src/Page/src/RoutesDelegator.php
+++ b/src/Page/src/RoutesDelegator.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Light\Page;
 
-use Light\Page\Handler\PageHandler;
+use Light\Page\Handler\GetPageViewHandler;
 use Mezzio\Application;
 use Psr\Container\ContainerExceptionInterface;
 use Psr\Container\ContainerInterface;
@@ -25,12 +25,12 @@ class RoutesDelegator
         assert($app instanceof Application);
 
         $routes = $container->get('config')['routes'] ?? [];
-        foreach ($routes as $moduleName => $moduleRoutes) {
+        foreach ($routes as $prefix => $moduleRoutes) {
             foreach ($moduleRoutes as $routeUri => $templateName) {
                 $app->get(
-                    sprintf('/%s/%s', $moduleName, $routeUri),
-                    [PageHandler::class],
-                    sprintf('%s::%s', $moduleName, $templateName)
+                    sprintf('/%s/%s', $prefix, $routeUri),
+                    GetPageViewHandler::class,
+                    sprintf('%s::%s', $prefix, $templateName)
                 );
             }
         }

--- a/test/Unit/Page/Handler/PageHandlerTest.php
+++ b/test/Unit/Page/Handler/PageHandlerTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace LightTest\Unit\Page\Handler;
 
 use Laminas\Diactoros\Response\HtmlResponse;
-use Light\Page\Handler\PageHandler;
+use Light\Page\Handler\GetPageViewHandler;
 use Mezzio\Router\RouteResult;
 use Mezzio\Template\TemplateRendererInterface;
 use PHPUnit\Framework\MockObject\Exception;
@@ -20,7 +20,7 @@ class PageHandlerTest extends TestCase
      */
     public function testWillInstantiate(): void
     {
-        $handler = $this->createMock(PageHandler::class);
+        $handler = $this->createMock(GetPageViewHandler::class);
 
         $this->assertContainsOnlyInstancesOf(RequestHandlerInterface::class, [$handler]);
     }
@@ -49,7 +49,7 @@ class PageHandlerTest extends TestCase
             ->with($routeName)
             ->willReturn('<p>' . $routeName . '</p>');
 
-        $handler = new PageHandler($template);
+        $handler = new GetPageViewHandler($template);
 
         $response = $handler->handle($request);
 

--- a/test/Unit/Page/RoutesDelegatorTest.php
+++ b/test/Unit/Page/RoutesDelegatorTest.php
@@ -4,20 +4,24 @@ declare(strict_types=1);
 
 namespace LightTest\Unit\Page;
 
-use Light\Page\Handler\PageHandler;
+use Light\Page\Handler\GetPageViewHandler;
 use Light\Page\RoutesDelegator;
 use Mezzio\Application;
 use Mezzio\Router\Route;
 use PHPUnit\Framework\MockObject\Exception;
 use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerExceptionInterface;
 use Psr\Container\ContainerInterface;
+use Psr\Container\NotFoundExceptionInterface;
 
 use function sprintf;
 
 class RoutesDelegatorTest extends TestCase
 {
     /**
+     * @throws ContainerExceptionInterface
      * @throws Exception
+     * @throws NotFoundExceptionInterface
      */
     public function testWillInvoke(): void
     {
@@ -35,7 +39,7 @@ class RoutesDelegatorTest extends TestCase
             ->method('get')
             ->willReturnCallback(function (...$args) use ($routeUri, $templateName) {
                 $this->assertSame($routeUri, $args[0]);
-                $this->assertSame([[PageHandler::class]], [$args[1]]);
+                $this->assertSame([GetPageViewHandler::class], [$args[1]]);
                 $this->assertSame($templateName, $args[2]);
             });
 


### PR DESCRIPTION
Also:
- bumped `dotkernel/dot-errorhandler` to `4.2.1` and enabled the trace route provider in compact format
- `src/Page/src/RoutesDelegator.php` **L28**: renamed `$moduleName` => `$prefix` to better reflect the variable's purpose
- removed unused `mezzio` Composer command which did not work properly. Running `composer mezzio` threw:

```shell
> mezzio --ansi
sh: line 1: mezzio: command not found
```