### PR TITLE
Issue #97: Create workflow file that builds the JS/CSS assets

### DIFF
--- a/.github/workflows/build-assets.yml
+++ b/.github/workflows/build-assets.yml
@@ -28,3 +28,6 @@ jobs:
 
       - name: Build assets
         run: npm run build
+
+      - name: Audit dependencies
+        run: npm audit --audit-level=critical

--- a/.github/workflows/build-assets.yml
+++ b/.github/workflows/build-assets.yml
@@ -1,0 +1,27 @@
+name: Build Assets
+
+on: push
+
+jobs:
+  build:
+    name: Build assets (Node ${{ matrix.node-version }})
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: ["20", "22", "24", "26"]
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Set up Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v6
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Build assets
+        run: npm run build

--- a/.github/workflows/build-assets.yml
+++ b/.github/workflows/build-assets.yml
@@ -2,6 +2,9 @@ name: Build Assets
 
 on: push
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Build assets (Node ${{ matrix.node-version }})

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Documentation is available at: https://docs.dotkernel.org/light-documentation/
 [![Continuous Integration](https://github.com/dotkernel/light/actions/workflows/continuous-integration.yml/badge.svg?branch=1.0)](https://github.com/dotkernel/light/actions/workflows/continuous-integration.yml)
 [![codecov](https://codecov.io/gh/dotkernel/light/graph/badge.svg?token=UpVJ5ELvfZ)](https://codecov.io/gh/dotkernel/light)
 [![Qodana](https://github.com/dotkernel/light/actions/workflows/qodana_code_quality.yml/badge.svg)](https://github.com/dotkernel/light/actions/workflows/qodana_code_quality.yml)
+[![Assets](https://github.com/dotkernel/light/actions/workflows/build-assets.yml/badge.svg)](https://github.com/dotkernel/light/actions/workflows/build-assets.yml)
 
 [![PHPStan](https://github.com/dotkernel/light/actions/workflows/static-analysis.yml/badge.svg?branch=1.0)](https://github.com/dotkernel/light/actions/workflows/static-analysis.yml)
 ![PHPstan Level](https://img.shields.io/badge/PHPStan-level%208-brightgreen)

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Documentation is available at: https://docs.dotkernel.org/light-documentation/
 [![Continuous Integration](https://github.com/dotkernel/light/actions/workflows/continuous-integration.yml/badge.svg?branch=1.0)](https://github.com/dotkernel/light/actions/workflows/continuous-integration.yml)
 [![codecov](https://codecov.io/gh/dotkernel/light/graph/badge.svg?token=UpVJ5ELvfZ)](https://codecov.io/gh/dotkernel/light)
 [![Qodana](https://github.com/dotkernel/light/actions/workflows/qodana_code_quality.yml/badge.svg)](https://github.com/dotkernel/light/actions/workflows/qodana_code_quality.yml)
-[![Build Assets](https://github.com/dotkernel/light/actions/workflows/build-assets.yml/badge.svg)](https://github.com/dotkernel/light/actions/workflows/build-assets.yml)
+[![Build Assets](https://github.com/dotkernel/light/actions/workflows/build-assets.yml/badge.svg?branch=1.0)](https://github.com/dotkernel/light/actions/workflows/build-assets.yml)
 
 [![PHPStan](https://github.com/dotkernel/light/actions/workflows/static-analysis.yml/badge.svg?branch=1.0)](https://github.com/dotkernel/light/actions/workflows/static-analysis.yml)
 ![PHPstan Level](https://img.shields.io/badge/PHPStan-level%208-brightgreen)

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Documentation is available at: https://docs.dotkernel.org/light-documentation/
 [![Continuous Integration](https://github.com/dotkernel/light/actions/workflows/continuous-integration.yml/badge.svg?branch=1.0)](https://github.com/dotkernel/light/actions/workflows/continuous-integration.yml)
 [![codecov](https://codecov.io/gh/dotkernel/light/graph/badge.svg?token=UpVJ5ELvfZ)](https://codecov.io/gh/dotkernel/light)
 [![Qodana](https://github.com/dotkernel/light/actions/workflows/qodana_code_quality.yml/badge.svg)](https://github.com/dotkernel/light/actions/workflows/qodana_code_quality.yml)
-[![Assets](https://github.com/dotkernel/light/actions/workflows/build-assets.yml/badge.svg)](https://github.com/dotkernel/light/actions/workflows/build-assets.yml)
+[![Build Assets](https://github.com/dotkernel/light/actions/workflows/build-assets.yml/badge.svg)](https://github.com/dotkernel/light/actions/workflows/build-assets.yml)
 
 [![PHPStan](https://github.com/dotkernel/light/actions/workflows/static-analysis.yml/badge.svg?branch=1.0)](https://github.com/dotkernel/light/actions/workflows/static-analysis.yml)
 ![PHPstan Level](https://img.shields.io/badge/PHPStan-level%208-brightgreen)


### PR DESCRIPTION
# Summary

Created new workflow file that builds the JS/CSS assets: `.github/workflows/build-assets.yml`.
- runs on **Node.js** versions `20`, `22`, `24` and `26` (version `18` failed, version `26` is the latest)
- for each Node.JS version it does the following:
  - it runs the command `npm install` to install the dependencies from `package.json`
  - it runs the command `npm run build` to build all JS/CSS assets

## Note:

There is one more thing we could/should add to this workflow file:
```yaml
      - name: Audit dependencies
        run: npm audit --audit-level=critical
```
With this, an action would also LOOK for and FAIL when a package with known vulnerabilities is installed.

Note the line `run: npm audit --audit-level=critical`.
This contains an `audit-level` parameter where we can specify at which vulnerability level should the action fail.
The possible values are:
- **low**
- **moderate**
- **high**
- **critical**

My suggestion - if we enable this feature - is to start from **critical** and once we solve for those, we can maybe lower the level to **high**.
Lower than that would probably not be needed because JS packages often have **low** to **minor** vulnerabilities, _it's normal_.